### PR TITLE
(doc) YARD: return type fix, names

### DIFF
--- a/lib/tty/which.rb
+++ b/lib/tty/which.rb
@@ -7,9 +7,9 @@ module TTY
   module Which
     # Find an executable in a platform independent way
     #
-    # @param [String] command
+    # @param [String] cmd
     #   the command to search for
-    # @param [Array[String]] paths
+    # @param [Array<String>] paths
     #   the paths to look through
     #
     # @example
@@ -50,10 +50,10 @@ module TTY
 
     # Check if executable exists in the path
     #
-    # @param [String] command
+    # @param [String] cmd
     #   the executable to check
     #
-    # @param [String] paths
+    # @param [Array<String>] paths
     #   paths to check
     #
     # @return [Boolean]
@@ -73,7 +73,7 @@ module TTY
     #   search_paths("/usr/local/bin:/bin")
     #   # => ['/bin']
     #
-    # @return [Array[String]]
+    # @return [Array<String>]
     #   the array of paths to search
     #
     # @api private
@@ -96,7 +96,7 @@ module TTY
     # @param [String] path_ext
     #   a string of semicolon separated filename extensions
     #
-    # @return [Array[String]]
+    # @return [Array<String>]
     #   an array with valid file extensions
     #
     # @api private


### PR DESCRIPTION
### Describe the change

This PR fixes warnings about API docs generation.

### Why are we doing this?

We do this to keep the API docs accurate.


### Benefits

A parameter will show up with its name correctly, and a return type will be described using the YARD type description which YARD's parser understands. See here for details: https://yardoc.org/types.html

### Drawbacks

n/a

### Requirements
Put an X between brackets on each line if you have done the item:
- [ ] Tests written & passing locally?
- [ ] Code style checked?
- [ ] Rebased with `master` branch?
- [x] Documentaion updated?
